### PR TITLE
one_of fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ build/
 *.txt.user
 .vscode/
 .vs/
+target/
 CMakeSettings.json


### PR DESCRIPTION
The hit_flags feature of the token parsing phase causes one_of not to detect duplicates.  Need to revisit this though.