### PR TITLE
Remove DOCS_ONLY option

### DIFF
--- a/.github/workflows/docs_pusher.yml
+++ b/.github/workflows/docs_pusher.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         mkdir -p ${{ env.BUILD_DIR }}
         cd ${{ env.BUILD_DIR }}
-        cmake ${{ github.workspace }} -DDOCS_ONLY=ON
+        cmake ${{ github.workspace }} -DINSTALLATION_ONLY=ON
         cmake --build . --target documentation
 
     - name: Deploy

--- a/.github/workflows/merge_checker.yml
+++ b/.github/workflows/merge_checker.yml
@@ -178,8 +178,8 @@ jobs:
       run: |
         mkdir -p ${{ env.BUILD_DIR }}
         cd ${{ env.BUILD_DIR }}
-        cmake ${{ github.workspace }} -DDEATH_TEST_PARALLEL=2
-        cmake --build . --target arg_router_test -j2
+        cmake ${{ github.workspace }} -DDEATH_TEST_PARALLEL=3
+        cmake --build . --target arg_router_test -j3
 
     - name: Run unit tests
       timeout-minutes: 30

--- a/.github/workflows/pr_checker.yml
+++ b/.github/workflows/pr_checker.yml
@@ -191,5 +191,5 @@ jobs:
       run: |
         mkdir -p ${{ env.BUILD_DIR }}
         cd ${{ env.BUILD_DIR }}
-        cmake ${{ github.workspace }} -DDOCS_ONLY=ON
+        cmake ${{ github.workspace }} -DINSTALLATION_ONLY=ON
         cmake --build . --target documentation

--- a/.github/workflows/release_builder.yml
+++ b/.github/workflows/release_builder.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         mkdir -p ${{ env.BUILD_DIR }}
         cd ${{ env.BUILD_DIR }}
-        cmake ${{ github.workspace }} -G "Ninja" -DDOCS_ONLY=ON
+        cmake ${{ github.workspace }} -G "Ninja" -DINSTALLATION_ONLY=ON
         cmake --build . --target package
 
     - name: Check versions match

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,19 +4,19 @@ cmake_minimum_required(VERSION 3.18)
 
 include(CMakeDependentOption)
 
-option(DOCS_ONLY "Only build the documentation" OFF)
+option(INSTALLATION_ONLY "Just 'build' for installation" OFF)
 cmake_dependent_option(BUILD_UNIT_TESTS_AND_EXAMPLES "Build the unit tests and examples" ON
-                       "NOT DOCS_ONLY" OFF)
+                       "NOT INSTALLATION_ONLY" OFF)
 cmake_dependent_option(ENABLE_CLANG_TIDY "Enable clang-tidy warnings for unit tests and examples" OFF
-                      "NOT DOCS_ONLY" OFF)
+                      "NOT INSTALLATION_ONLY" OFF)
 cmake_dependent_option(ENABLE_SANITIZERS "Enable ASan/UBSan for unit tests and examples" OFF
-                       "NOT DOCS_ONLY" OFF)
+                       "NOT INSTALLATION_ONLY" OFF)
 cmake_dependent_option(DISABLE_VCPKG "Disable vcpkg, use system libraries" OFF
-                       "NOT DOCS_ONLY" OFF)
+                       "NOT INSTALLATION_ONLY" OFF)
 
 # Use the libraries brought in from vcpkg rather than the system ones
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/path_prefixer.cmake")
-if((NOT DOCS_ONLY) AND (NOT DISABLE_VCPKG))
+if(NOT DISABLE_VCPKG)
     path_prefixer(CMAKE_TOOLCHAIN_FILE vcpkg/scripts/buildsystems/vcpkg.cmake)
 endif()
 
@@ -33,14 +33,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" OR CMAKE_CXX_COMPILER_FRONTEND_VARIANT
 endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/versioning/version.cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/copyright_checker.cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake")
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_types/documentation.cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-tidy.cmake")
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/sanitizers.cmake")
 
-# Only find packages if we're not doing a Docs-only build
-if(NOT DOCS_ONLY)
+if(NOT INSTALLATION_ONLY)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/copyright_checker.cmake")
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/config.cmake")
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-tidy.cmake")
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/sanitizers.cmake")
     include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/ccache.cmake")
 
     find_package(span-lite)
@@ -154,12 +153,14 @@ path_prefixer(FOR_IDE
     vcpkg.json
 )
 
-include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-format.cmake")
-create_clangformat_target(
-    NAME clangformat
-    FORMAT_FILE ${CMAKE_SOURCE_DIR}/.clang-format
-    SOURCES ${HEADERS}
-)
+if(NOT INSTALLATION_ONLY)
+    include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/clang-format.cmake")
+    create_clangformat_target(
+        NAME clangformat
+        FORMAT_FILE ${CMAKE_SOURCE_DIR}/.clang-format
+        SOURCES ${HEADERS}
+    )
+endif()
 
 include("${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_types/library.cmake")
 

--- a/cmake/build_types/documentation.cmake
+++ b/cmake/build_types/documentation.cmake
@@ -1,9 +1,5 @@
 ### Copyright (C) 2022 by Camden Mannett.  All rights reserved. 
 
-if(DOCS_ONLY)
-    message(STATUS "Documentation-only build")
-endif()
-
 path_prefixer(DOCS_FOR_IDE
     cmake/build_types/documentation_script.cmake
     docs/Doxyfile
@@ -28,17 +24,10 @@ set(DOCS_COMMAND
     -P "${CMAKE_CURRENT_SOURCE_DIR}/cmake/build_types/documentation_script.cmake"
 )
 
-if (DOCS_ONLY)
-    add_custom_target(documentation ALL
-        COMMAND ${DOCS_COMMAND}
-        SOURCES ${DOCS_FOR_IDE}
-    )
-else()
-    add_custom_target(documentation
-        COMMAND ${DOCS_COMMAND}
-        SOURCES ${DOCS_FOR_IDE}
-    )
-endif()
+add_custom_target(documentation
+    COMMAND ${DOCS_COMMAND}
+    SOURCES ${DOCS_FOR_IDE}
+)
 
 # We have touch the generated API readme because CPack configuration will fail if it is not there.
 # set_source_files_properties cannot be used in a script so that's set here too

--- a/cmake/build_types/library.cmake
+++ b/cmake/build_types/library.cmake
@@ -1,8 +1,11 @@
 ### Copyright (C) 2022 by Camden Mannett.  All rights reserved.
 
 add_library(arg_router INTERFACE ${HEADERS} ${FOR_IDE})
-add_dependencies(arg_router clangformat)
 target_compile_features(arg_router INTERFACE cxx_std_17)
 target_include_directories(arg_router
     INTERFACE "${CMAKE_SOURCE_DIR}/include"
 )
+
+if(NOT INSTALLATION_ONLY)
+    add_dependencies(arg_router clangformat)
+endif()


### PR DESCRIPTION
It's confusing and not very useful.  Replaced with an INSTALLTION_ONLY
option that simply doesn't do any building or package finding.