### PR TITLE
Various GCC and 32bit fixes

### DIFF
--- a/include/arg_router/utility/compile_time_string.hpp
+++ b/include/arg_router/utility/compile_time_string.hpp
@@ -475,13 +475,16 @@ struct builder {
 
     using type = decltype(list_to_string(strip_null{}));
 };
+
+template <char... Cs>
+using builder_t = typename builder<Cs...>::type;
 }  // namespace cts_detail
 }  // namespace arg_router::utility
 
 #    define AR_STR_CHAR(z, n, tok) arg_router::utility::cts_detail::get(tok, n)
 
 #    define AR_STR_N(n, tok) \
-        typename arg_router::utility::cts_detail::builder<BOOST_PP_ENUM(n, AR_STR_CHAR, tok)>::type
+        arg_router::utility::cts_detail::builder_t<BOOST_PP_ENUM(n, AR_STR_CHAR, tok)>
 
 /** Macro that represents the type of a compile-time string, useful for policies that require a
  * compile string.

--- a/include/arg_router/utility/type_hash.hpp
+++ b/include/arg_router/utility/type_hash.hpp
@@ -8,91 +8,25 @@
 
 namespace arg_router::utility
 {
-namespace detail
-{
-// constexpr hash combine implementations, based on Boost's equivalent:
-// https://github.com/boostorg/container_hash/blob/boost-1.74.0/include/boost/container_hash/hash.hpp#L316
-[[nodiscard]] constexpr std::size_t hash_combine(std::size_t a, std::size_t b) noexcept
-{
-    // NOLINTBEGIN(readability-magic-numbers)
-    static_assert((sizeof(std::size_t) == 4) || (sizeof(std::size_t) == 8),
-                  "std::size_t must be 32 or 64 bits");
-
-    // Personally, I hate this and previously had it as two separate overloads, but that caused
-    // ambiguity on AppleClang hence this approach
-    if constexpr (sizeof(std::size_t) == 4) {
-        constexpr auto c1 = std::uint32_t{0xcc9e2d51};
-        constexpr auto c2 = std::uint32_t{0x1b873593};
-
-        b *= c1;
-        b = (b << 15) | (b >> (32 - 15));  // ROTL 15 bits
-        b *= c2;
-
-        a ^= b;
-        a = (a << 13) | (a >> (32 - 13));  // ROTL 13 bits
-        a = a * 5 + 0xe6546b64;
-
-        return a;
-    } else {
-        constexpr auto m = std::uint64_t{0xc6a4a7935bd1e995};
-        constexpr auto r = 47;
-
-        b *= m;
-        b ^= b >> r;
-        b *= m;
-
-        a ^= b;
-        a *= m;
-
-        // Completely arbitrary number, to prevent 0's from hashing to 0.
-        a += 0xe6546b64;
-
-        return a;
-    }
-    // NOLINTEND(readability-magic-numbers)
-}
-
-// Do this rather than just put the generate() body into type_hash(), because otherwise the compiler
-// puts the pretty function output into static storage, needlessly bloating exe size
-template <typename T>
-class type_hash_t
-{
-    [[nodiscard]] constexpr static std::size_t generate() noexcept
-    {
-        // Because we can't guarantee default construction support for T and reinterpret_cast is not
-        // allowed in constant evaluation, we'll resort to the (valid, but) dirty hack of using the
-        // function signature (which contains the fully qualified name of T)
-#ifdef _MSC_VER
-        constexpr auto sig = std::string_view{__FUNCSIG__};
-#else
-        constexpr auto sig = std::string_view{static_cast<const char*>(__PRETTY_FUNCTION__)};
-#endif
-
-        auto result = std::size_t{0};
-        for (auto c : sig) {
-            result = detail::hash_combine(result, c);
-        }
-
-        return result;
-    }
-
-public:
-    constexpr static auto value = generate();
-};
-}  // namespace detail
-
-/** Compile-time hash generation for a type.
+/** Hash generation for a type.
  *
  * This is intended to replace <TT>typeid(T).hash_code()</TT>, as the use of typeid causes huge
  * amounts of class name data to be put into the binary's static data storage - which isn't used!
+ *
  * @note Aliases are resolved by the compiler in a pre-processing stage before this, so
  * <TT>type_hash<std::uint64_t>() == type_hash<unsigned long>()</TT> (on a 64bit system)
+ *
+ * Anyone reading the implementation will see that this is @em not a hash function, it just takes
+ * the address of the instantiated function.  Originally this used the hash of the
+ * <TT>__PRETTY_FUNCTION__</TT> output and therefore could be used at compile-time.  Unfortunately
+ * that was ruined when C++20 compile-time string support was added, due to a bug in gcc which
+ * produced incorrect output when <TT>std::array</TT> was used inside an NTTP.
  * @param T Type to generate a hash code for
  * @return Hash code of @a T
  */
 template <typename T>
-[[nodiscard]] constexpr std::size_t type_hash() noexcept
+[[nodiscard]] std::size_t type_hash() noexcept
 {
-    return detail::type_hash_t<T>::value;
+    return reinterpret_cast<std::size_t>(&type_hash<T>);
 }
 }  // namespace arg_router::utility

--- a/test/allocator_test.cpp
+++ b/test/allocator_test.cpp
@@ -116,7 +116,11 @@ BOOST_FIXTURE_TEST_CASE(root_test, allocator_fixture)
             auto args = std::vector{"foo", "--hello"};
             r.parse(args.size(), const_cast<char**>(args.data()));
             BOOST_CHECK(router_hit);
-            BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 160u);
+            if constexpr (sizeof(std::uintptr_t) == 8) {
+                BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 160u);
+            } else {
+                BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 80u);
+            }
             BOOST_CHECK_EQUAL(allocator_fixture::current_bytes, 0u);
         }
 
@@ -129,7 +133,11 @@ BOOST_FIXTURE_TEST_CASE(root_test, allocator_fixture)
             BOOST_CHECK(false);
         } catch (parse_exception& e) {
             BOOST_CHECK(!router_hit);
-            BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 139u);
+            if constexpr (sizeof(std::uintptr_t) == 8) {
+                BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 139u);
+            } else {
+                BOOST_CHECK_GE(allocator_fixture::allocated_bytes, 96u);
+            }
             BOOST_CHECK_GE(allocator_fixture::current_bytes, 31u);
         }
     }

--- a/test/utility/type_hash_test.cpp
+++ b/test/utility/type_hash_test.cpp
@@ -28,8 +28,10 @@ BOOST_AUTO_TEST_CASE(negative_primitives_test)
             using second_type = std::tuple_element_t<j.value, primitive_types>;
 
             if constexpr (i != j) {
-                static_assert(utility::type_hash<first_type>() != utility::type_hash<second_type>(),
-                              "Test failed");
+                BOOST_CHECK_NE(utility::type_hash<first_type>(), utility::type_hash<second_type>());
+            } else {
+                BOOST_CHECK_EQUAL(utility::type_hash<first_type>(),
+                                  utility::type_hash<second_type>());
             }
         });
     });
@@ -40,8 +42,8 @@ BOOST_AUTO_TEST_CASE(positive_primitives_test)
     utility::tuple_type_iterator<primitive_types>([](auto i) {
         using primitive_type = std::tuple_element_t<i, primitive_types>;
 
-        static_assert(utility::type_hash<primitive_type>() == utility::type_hash<primitive_type>(),
-                      "Test failed");
+        BOOST_CHECK_EQUAL(utility::type_hash<primitive_type>(),
+                          utility::type_hash<primitive_type>());
     });
 }
 
@@ -58,24 +60,27 @@ BOOST_AUTO_TEST_CASE(node_test)
                              policy::router{[&](auto) {}}),
                         policy::validation::default_validator);
 
-    static_assert(utility::type_hash<decltype(a)>() != utility::type_hash<decltype(b)>(),
-                  "Test failed");
-    static_assert(utility::type_hash<decltype(a)>() == utility::type_hash<decltype(a)>(),
-                  "Test failed");
-    static_assert(utility::type_hash<decltype(b)>() == utility::type_hash<decltype(b)>(),
-                  "Test failed");
+    BOOST_CHECK_NE(utility::type_hash<decltype(a)>(), utility::type_hash<decltype(b)>());
+    BOOST_CHECK_EQUAL(utility::type_hash<decltype(a)>(), utility::type_hash<decltype(a)>());
+    BOOST_CHECK_EQUAL(utility::type_hash<decltype(b)>(), utility::type_hash<decltype(b)>());
 }
 
 BOOST_AUTO_TEST_CASE(const_test)
 {
-    static_assert(utility::type_hash<const int>() != utility::type_hash<int>(), "Test failed");
+    BOOST_CHECK_NE(utility::type_hash<const int>(), utility::type_hash<int>());
 }
 
 BOOST_AUTO_TEST_CASE(alias_test)
 {
     using alias_type = std::uint64_t;
-    static_assert(utility::type_hash<alias_type>() == utility::type_hash<std::uint64_t>(),
-                  "Test failed");
+    BOOST_CHECK_EQUAL(utility::type_hash<alias_type>(), utility::type_hash<std::uint64_t>());
+}
+
+BOOST_AUTO_TEST_CASE(short_name_test)
+{
+    auto a = flag(policy::short_name<'a'>);
+    auto b = flag(policy::short_name<'b'>);
+    BOOST_CHECK_NE(utility::type_hash<decltype(a)>(), utility::type_hash<decltype(b)>());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- Hashing __PRETTY_FUNCTION__ doesn't work on GCC due to a bug regarding std::array as a NTTP
- Allocator test byte counts fixed for 32 bit