### PR TITLE
arg_router v1.2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if((NOT INSTALLATION_ONLY) AND (NOT DISABLE_VCPKG))
 endif()
 
 project(arg_router
-        VERSION 1.1.1
+        VERSION 1.2.0
         DESCRIPTION "C++ command line argument parsing and routing"
         HOMEPAGE_URL "https://github.com/cmannett85/arg_router"
         LANGUAGES CXX)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = arg_router
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1.1
+PROJECT_NUMBER         = 1.2.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/arg_router/version.hpp
+++ b/include/arg_router/version.hpp
@@ -14,5 +14,5 @@ namespace arg_router
 {
 /** Library version as a SymVers-style string.
  */
-constexpr auto version_string = "1.1.1";
+constexpr auto version_string = "1.2.0";
 }  // namespace arg_router


### PR DESCRIPTION
Bug fixes
* #254, passing no args to short_form_expander_t::pre_parse_phase(..) causes segfault
* #255, policy_unique_from_owner_parent_to_mode_or_root not working

Improvements
* Corrected CMake package so you don't need to manually set the include directory anymore (#257)
* Node can be instantiated with bare compile-time strings and they are automatically mapped to the appropriate policy (#256)
* Improved help output formatting documentation (#258)