### PR TITLE
arg_router v1.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if((NOT INSTALLATION_ONLY) AND (NOT DISABLE_VCPKG))
 endif()
 
 project(arg_router
-        VERSION 1.3.0
+        VERSION 1.4.0
         DESCRIPTION "C++ command line argument parsing and routing"
         HOMEPAGE_URL "https://github.com/cmannett85/arg_router"
         LANGUAGES CXX)

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -47,7 +47,7 @@ PROJECT_NAME           = arg_router
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.3.0
+PROJECT_NUMBER         = 1.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/arg_router/version.hpp
+++ b/include/arg_router/version.hpp
@@ -14,5 +14,5 @@ namespace arg_router
 {
 /** Library version as a SymVers-style string.
  */
-constexpr auto version_string = "1.3.0";
+constexpr auto version_string = "1.4.0";
 }  // namespace arg_router


### PR DESCRIPTION
Bug fixes
* #330, Explicitly specify NOMINMAX and WIN32_LEAN_AND_MEAN

Improvements
* #302, Switch from a locally generated Conan package, to one hosted on conan-center.io
* #314, Add support for multi-value arguments
* #315, CMake function to generate translation type headers from simple text files
* #317, Enable/disable nodes at runtime
* #318, Skip irrelevant GHA jobs
* #321, Add variable list length end token
* #325, Create copyright checker git hook
* #332, Extend pre-commit hook to include clang-format
* #335, Use Levenshtein distance to suggest possibly misspelt arguments