### PR TITLE
#386 Replace AR_STRING_SV

### DIFF
--- a/examples/custom_policy_and_node/main.cpp
+++ b/examples/custom_policy_and_node/main.cpp
@@ -132,12 +132,9 @@ public:
         // Do not just use *this as the generate argument because it will trigger an infinite loop!
         auto result = ar::help_data::generate<Flatten>(static_cast<const parent_type&>(*this), f);
 
-        // This is unfortunately necessary due to C++ language limitations, we can't pass
-        // a std::string_view directly to ar::str
-        constexpr auto name = single_positional_arg_t::display_name();
-        constexpr auto name_span = std::span<const char, name.size()>{name};
-
-        result.label = ("<"_S + ar::str<name_span>{} + "> "_S +
+        // AR_STR_SV(..) is a macro that allows compile-time strings to be instantiated with a
+        // std::string_view.  This can't be done without a macro due to language limitations
+        result.label = ("<"_S + AR_STR_SV(single_positional_arg_t::display_name()){} + "> "_S +
                         ar::help_data::count_suffix<single_positional_arg_t>())
                            .get();
 

--- a/include/arg_router/dependency/alias_group.hpp
+++ b/include/arg_router/dependency/alias_group.hpp
@@ -108,7 +108,7 @@ public:
     {
         auto result = parent_type::template generate_help_data<Flatten>(f);
         result.label =
-            (AR_STRING_SV(parent_type::display_name()){} + help_data::value_suffix<alias_group_t>())
+            (AR_STR_SV(parent_type::display_name()){} + help_data::value_suffix<alias_group_t>())
                 .get();
 
         return result;

--- a/include/arg_router/dependency/detail.hpp
+++ b/include/arg_router/dependency/detail.hpp
@@ -28,7 +28,7 @@ private:
         constexpr static auto build()
         {
             constexpr auto token = parsing::node_token_type<Child>();
-            return AR_STRING_SV(parsing::to_string(token.prefix)){} + AR_STRING_SV(token.name){};
+            return AR_STR_SV(parsing::to_string(token.prefix)){} + AR_STR_SV(token.name){};
         }
 
         using type = typename std::decay_t<decltype(build())>;

--- a/include/arg_router/help_data.hpp
+++ b/include/arg_router/help_data.hpp
@@ -169,7 +169,7 @@ template <typename Node>
         std::tuple_size_v<typename Node::policies_type>;
 
     if constexpr (has_separator) {
-        return AR_STRING_SV(Node::value_separator()){} + value_str;
+        return AR_STR_SV(Node::value_separator()){} + value_str;
     } else if constexpr (fixed_count_of_one) {
         return str<" ">{} + value_str;
     } else {
@@ -196,17 +196,17 @@ template <typename Node>
         boost::mp11::mp_find_if<policies_type, traits::has_none_name_method>::value != num_policies;
 
     if constexpr (has_long_name && has_short_name) {
-        return AR_STRING_SV(config::long_prefix){} + AR_STRING_SV(Node::long_name()){} +
-               str<",">{} + AR_STRING_SV(config::short_prefix){} +
-               AR_STRING_SV(Node::short_name()){} + value_separator_suffix<Node>();
+        return AR_STR_SV(config::long_prefix){} + AR_STR_SV(Node::long_name()){} + str<",">{} +
+               AR_STR_SV(config::short_prefix){} + AR_STR_SV(Node::short_name()){} +
+               value_separator_suffix<Node>();
     } else if constexpr (has_long_name) {
-        return AR_STRING_SV(config::long_prefix){} + AR_STRING_SV(Node::long_name()){} +
+        return AR_STR_SV(config::long_prefix){} + AR_STR_SV(Node::long_name()){} +
                value_separator_suffix<Node>();
     } else if constexpr (has_short_name) {
-        return AR_STRING_SV(config::short_prefix){} + AR_STRING_SV(Node::short_name()){} +
+        return AR_STR_SV(config::short_prefix){} + AR_STR_SV(Node::short_name()){} +
                value_separator_suffix<Node>();
     } else if constexpr (has_none_name) {
-        return AR_STRING_SV(Node::none_name()){} + value_separator_suffix<Node>();
+        return AR_STR_SV(Node::none_name()){} + value_separator_suffix<Node>();
     } else {
         return str<"">{};
     }
@@ -224,7 +224,7 @@ template <typename Node>
         std::tuple_size_v<typename Node::policies_type>;
 
     if constexpr (has_description) {
-        return AR_STRING_SV(Node::description()){};
+        return AR_STR_SV(Node::description()){};
     } else {
         return str<"">{};
     }

--- a/include/arg_router/policy/short_name.hpp
+++ b/include/arg_router/policy/short_name.hpp
@@ -39,7 +39,7 @@ public:
     [[nodiscard]] constexpr static std::string_view short_name() noexcept { return S::get(); }
 
 private:
-    using full_name_type = AR_STRING_SV(config::short_prefix)::append_t<S>;
+    using full_name_type = AR_STR_SV(config::short_prefix)::append_t<S>;
 
     static_assert(utility::utf8::count(short_name()) == 1, "Short name must only be one character");
     static_assert(full_name_type::get() != config::long_prefix,

--- a/include/arg_router/traits.hpp
+++ b/include/arg_router/traits.hpp
@@ -4,10 +4,7 @@
 
 #pragma once
 
-#include "arg_router/tree_node_fwd.hpp"
-
 #include <boost/mp11/algorithm.hpp>
-#include <boost/mp11/bind.hpp>
 #include <boost/mp11/utility.hpp>
 
 #include <algorithm>

--- a/include/arg_router/utility/exception_formatter.hpp
+++ b/include/arg_router/utility/exception_formatter.hpp
@@ -70,8 +70,7 @@ class exception_formatter
                 Str,
                 boost::mp11::mp_push_back<
                     PHs,
-                    placeholder<start,
-                                AR_STRING_SV(Str::get().substr(start + 1, end - start - 1))>>,
+                    placeholder<start, AR_STR_SV(Str::get().substr(start + 1, end - start - 1))>>,
                 end + 1>();
         } else {
             return PHs{};


### PR DESCRIPTION
Can't do this sadly as the language won't permit it - you can't use a std::string_view as a template parameter and function args are not constant expressions. Best I can do is make the macro documented.

Fix #386